### PR TITLE
Fix GitHub Pages deployment (switch to Actions artifact pipeline)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,10 +6,16 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,4 +23,17 @@ jobs:
         with:
           python-version: "3.x"
       - run: pip install -r requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build --strict
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem
After merging #7, GitHub Pages kept serving a Jekyll build of `main`/`docs` instead of the MkDocs Material site, even after switching the Pages source to the `gh-pages` branch (which does have the correct built content — verified by cloning it directly). Root cause: `build_type` was still `legacy`, so GitHub's own auto-Jekyll builder kept winning over the `mkdocs gh-deploy` branch push.

## Fix
Switch to the official Actions-based Pages deployment pattern:
- `mkdocs build --strict` produces the `site/` directory
- `actions/upload-pages-artifact` packages it
- `actions/deploy-pages` publishes it via GitHub's Pages deployment API

No branch push involved, so there's no `gh-pages` branch to fight the legacy builder over. `build_type` on the repo has already been set to `workflow` to match.

## Test plan
- [x] Confirmed `gh-pages` branch content was correct (root cause was the deploy mechanism, not the build)
- [ ] After merge, confirm https://titusm.github.io/Cisco-Data-Center/ serves the MkDocs Material theme, not Jekyll