### PR TITLE
Make command blocks collapsible (hidden by default)

### DIFF
--- a/docs/ucs-san/01-pre-lab.md
+++ b/docs/ucs-san/01-pre-lab.md
@@ -12,39 +12,43 @@ On a factory-default Nexus 5000, the boot process drops you into the interactive
 
 Confirm the result is genuinely blank before moving on — with one exception. This pod's baseline has **NPIV already enabled on N5K-3/N5K-4** before you touch anything, so don't expect (or write-erase away) a truly feature-less state on those two switches:
 
-```text
-show vlan brief        ! should show only VLAN 1
-show vsan               ! should show only VSAN 1 (SAN switches only)
-show feature | include enabled   ! N5K-1/N5K-2: nothing beyond platform defaults — vpc, fcoe off
-                                  ! N5K-3/N5K-4: npiv already enabled (pod baseline) — everything else off
-show running-config | include feature
-```
+??? "Commands"
+    ```text
+    show vlan brief        ! should show only VLAN 1
+    show vsan               ! should show only VSAN 1 (SAN switches only)
+    show feature | include enabled   ! N5K-1/N5K-2: nothing beyond platform defaults — vpc, fcoe off
+                                      ! N5K-3/N5K-4: npiv already enabled (pod baseline) — everything else off
+    show running-config | include feature
+    ```
 
 !!! warning "N5K-3, N5K-4 — confirm, don't configure, NPIV"
     Because this pod ships with `feature npiv` already turned on for the SAN switches, this is a verification step, not a build step — toggling a feature that's already live risks bouncing existing FLOGIs for no reason. Confirm it's on before you rely on it anywhere downstream (Module 2's F-port trunk needs it already enabled the moment that trunk comes up, and Module 6 verifies it in depth):
 
-```text
-! N5K-3, N5K-4 — confirm only
-show feature | include npiv     ! expect: npiv    1        enabled
-show running-config | include npiv
-```
+??? "Commands"
+    ```text
+    ! N5K-3, N5K-4 — confirm only
+    show feature | include npiv     ! expect: npiv    1        enabled
+    show running-config | include npiv
+    ```
 
 If it comes back **disabled** on either switch — pod baseline wasn't applied, or someone reset it — enable it now rather than waiting for Module 2 to surface the failure indirectly:
 
-```text
-! N5K-3, N5K-4 — fallback only, if the confirm step above showed npiv disabled
-feature npiv
-```
+??? "Commands"
+    ```text
+    ! N5K-3, N5K-4 — fallback only, if the confirm step above showed npiv disabled
+    feature npiv
+    ```
 
 **Enable the remaining base features each switch will need**, since none of them are on by default and later modules assume they already are:
 
-```text
-! N5K-3, N5K-4 (SAN switches)
-feature fcoe          ! only if this pod uses FCoE rather than native FC uplinks
+??? "Commands"
+    ```text
+    ! N5K-3, N5K-4 (SAN switches)
+    feature fcoe          ! only if this pod uses FCoE rather than native FC uplinks
 
-! N5K-1, N5K-2 (LAN switches)
-feature vpc            ! only if you're building vPC to the FIs (Module 8)
-```
+    ! N5K-1, N5K-2 (LAN switches)
+    feature vpc            ! only if you're building vPC to the FIs (Module 8)
+    ```
 
 ## 1.2 FI-A, FI-B — Cluster Setup
 
@@ -56,33 +60,35 @@ A factory-default Fabric Interconnect also boots into an interactive setup wizar
 
 **Verify the cluster from the NX-OS-style CLI.** Connect to the cluster VIP (SSH or console) and confirm both FIs are up and which one is primary:
 
-```text
-FI-A# show cluster state
-Cluster Id: 0x4432f72a371511de-0xb97c000de1b1ada4
+??? "Commands"
+    ```text
+    FI-A# show cluster state
+    Cluster Id: 0x4432f72a371511de-0xb97c000de1b1ada4
 
-A: UP, PRIMARY
-B: UP, SUBORDINATE
+    A: UP, PRIMARY
+    B: UP, SUBORDINATE
 
-HA READY
-```
+    HA READY
+    ```
 
 The commands `show fabric-interconnect {a | b} detail` and `show system detail` display the IP addresses for the management interfaces and the virtual IP address, respectively, of the cluster:
 
-```text
-FI-A# show fabric-interconnect a detail
-Fabric Interconnect:
-    ID: A
-    OOB IP Addr: 10.10.10.11
-    OOB Gateway: 10.10.10.1
-    OOB Netmask: 255.255.255.0
-    ...
+??? "Commands"
+    ```text
+    FI-A# show fabric-interconnect a detail
+    Fabric Interconnect:
+        ID: A
+        OOB IP Addr: 10.10.10.11
+        OOB Gateway: 10.10.10.1
+        OOB Netmask: 255.255.255.0
+        ...
 
-FI-A# show system detail
-System:
-    Name: Nexus-DC-1-UCS
-    Virtual IP Addr: 10.10.10.10
-    ...
-```
+    FI-A# show system detail
+    System:
+        Name: Nexus-DC-1-UCS
+        Virtual IP Addr: 10.10.10.10
+        ...
+    ```
 
 !!! danger "HA NOT READY"
     If `show cluster state` reports **HA NOT READY**, stop here and check the L1/L2 cluster links between the two FIs before proceeding — a healthy L1/L2 connection is a prerequisite for everything that follows in Module 1.

--- a/docs/ucs-san/02-compute-policies.md
+++ b/docs/ucs-san/02-compute-policies.md
@@ -24,10 +24,11 @@ Chassis Discovery Policy is a **global policy** (**Equipment > Policies > Global
 
 **Verify:**
 
-```text
-show chassis detail
-show fex-connectivity        ! or equivalent under Equipment > Chassis > IO Modules, depending on platform
-```
+??? "Commands"
+    ```text
+    show chassis detail
+    show fex-connectivity        ! or equivalent under Equipment > Chassis > IO Modules, depending on platform
+    ```
 
 In the GUI: **Equipment > Chassis > IO Modules**, confirm the expected number of links per IOM shows **Up**, and that they're bundled into a port channel if Link Grouping Preference was set to Port Channel.
 
@@ -256,10 +257,11 @@ From the template, right-click **Create Service Profiles from Template**, genera
 
 **Verify:**
 
-```text
-show service-profile status
-show server inventory (via UCSM CLI: scope org / scope service-profile <name> / show config)
-```
+??? "Commands"
+    ```text
+    show service-profile status
+    show server inventory (via UCSM CLI: scope org / scope service-profile <name> / show config)
+    ```
 
 In the GUI: **Servers > Service Profiles**, confirm Assoc State = `associated`, Overall Status = `ok`.
 
@@ -284,12 +286,13 @@ In the GUI: **Servers > Service Profiles**, confirm Assoc State = `associated`, 
 
 **CLI equivalent**, for the same result:
 
-```text
-scope org
-scope service-profile Blade02
-set src-templ-name ""
-commit-buffer
-```
+??? "Commands"
+    ```text
+    scope org
+    scope service-profile Blade02
+    set src-templ-name ""
+    commit-buffer
+    ```
 
 **What actually changes:** unbinding only removes the link to the parent template — it does **not** revert or clear anything. `Blade02` keeps every setting and resource it already had (VLANs, VSANs, boot policy, pools, everything from the last time it matched the template) and simply becomes a **static, independent service profile** from that point on. You can now edit `Blade02` directly, and — just as important — the reverse is now also true: if you go back and change `SPT-ESX-SANBoot` itself, `Blade02` no longer picks up that change, while `Blade01` (still bound) does. That asymmetry is the actual trade-off, not a side effect: unbinding buys per-profile flexibility at the cost of that one profile falling out of the template's future updates until you explicitly **Bind to a Template** again (same General tab, **Actions > Bind to a Template**).
 

--- a/docs/ucs-san/03-uplinks.md
+++ b/docs/ucs-san/03-uplinks.md
@@ -11,24 +11,25 @@ On each FI (UCSM: **Equipment > Fabric Interconnects > Fixed Module > Ethernet P
 
 On N5K-1/N5K-2, first create the local VLANs in the switch's own VLAN database (this is separate from the UCSM VLAN objects you created in Module 1, Task 1.1 — matching IDs are what tie the two together, not a shared database). VLAN 10 and 11 are shared, so both N5K uplink interfaces — the one toward FI-A and the one toward FI-B — carry the same Data/Mgmt pair. The one thing that must *not* be shared is the FCoE VLAN: it's bound to that fabric's VSANs (Module 4), so mixing FCoE VLAN 1000 onto the FI-B-facing interface (or 2000 onto the FI-A-facing one) would leak one fabric's SAN traffic onto the other's Ethernet path and defeat the point of keeping the SAN fabrics isolated:
 
-```text
-vlan 10
-  name Data
-vlan 11
-  name Mgmt
+??? "Commands"
+    ```text
+    vlan 10
+      name Data
+    vlan 11
+      name Mgmt
 
-! Toward FI-A
-interface Ethernet1/1
-  switchport mode trunk
-  switchport trunk allowed vlan 10,11,1000
-  no shutdown
+    ! Toward FI-A
+    interface Ethernet1/1
+      switchport mode trunk
+      switchport trunk allowed vlan 10,11,1000
+      no shutdown
 
-! Toward FI-B
-interface Ethernet1/2
-  switchport mode trunk
-  switchport trunk allowed vlan 10,11,2000
-  no shutdown
-```
+    ! Toward FI-B
+    interface Ethernet1/2
+      switchport mode trunk
+      switchport trunk allowed vlan 10,11,2000
+      no shutdown
+    ```
 
 If N5K-1/N5K-2 run vPC to each FI, see Module 8 for the vPC-specific config.
 
@@ -44,36 +45,38 @@ Set the FI's global SAN switching mode first, since it gates what an uplink port
 
 On N5K-3/N5K-4, the ports facing FI-A/FI-B must come up as **F ports** (fabric ports) so the FI can log in as an N-Port. Each fabric's core switch carries both of that fabric's VSANs (Boot + Data) over the same physical uplink, so the trunk allowed-list needs both IDs, not just one. `feature npiv` is **not** configured here — this pod already has it enabled per the Section 1.1 confirm step, and it needs to already be live the moment this F-port trunk comes up:
 
-```text
-! N5K-3 (Fabric A core)
-! feature npiv          — already enabled, confirmed in Section 1.1; not reconfigured here
-vsan database
-  vsan 100
-  vsan 101
-interface fc1/1
-  switchport mode F
-  switchport trunk allowed vsan 100,101
-  no shutdown
+??? "Commands"
+    ```text
+    ! N5K-3 (Fabric A core)
+    ! feature npiv          — already enabled, confirmed in Section 1.1; not reconfigured here
+    vsan database
+      vsan 100
+      vsan 101
+    interface fc1/1
+      switchport mode F
+      switchport trunk allowed vsan 100,101
+      no shutdown
 
-! N5K-4 (Fabric B core) — mirrors N5K-3 with Fabric B's VSANs
-! feature npiv          — already enabled, confirmed in Section 1.1; not reconfigured here
-vsan database
-  vsan 200
-  vsan 201
-interface fc1/1
-  switchport mode F
-  switchport trunk allowed vsan 200,201
-  no shutdown
-```
+    ! N5K-4 (Fabric B core) — mirrors N5K-3 with Fabric B's VSANs
+    ! feature npiv          — already enabled, confirmed in Section 1.1; not reconfigured here
+    vsan database
+      vsan 200
+      vsan 201
+    interface fc1/1
+      switchport mode F
+      switchport trunk allowed vsan 200,201
+      no shutdown
+    ```
 
 **Verify:**
 
-```text
-show interface brief
-show flogi database
-show fcns database vsan 100
-show fcns database vsan 101
-```
+??? "Commands"
+    ```text
+    show interface brief
+    show flogi database
+    show fcns database vsan 100
+    show fcns database vsan 101
+    ```
 
 You should see the FI's WWPN(s) FLOGI into the fabric as soon as the link and VSAN membership are correct — expect two logins per fabric once Module 1's boot and data vHBAs are both associated (one FLOGI/FDISC per vHBA, both riding the same physical F port).
 
@@ -90,14 +93,15 @@ A **VLAN Group** (UCSM: **LAN > LAN Cloud > VLAN Groups**) is a container of VLA
 2. **Pin each group to a preferred uplink:** in the same wizard (or by editing the group afterward), assign `VG-Data` to the uplink port/port-channel facing FI-A as its primary path, and `VG-Mgmt` to the uplink facing FI-B as its primary path, under **LAN Uplink Ports** / **Port Channels**. This is a preference, not an exclusion — both VLANs stay trunked on both uplinks (Task 2.1), so either one still fails over to the other uplink if its pinned path goes down.
 3. **Match the N5K side:** the trunk `allowed vlan` list on both N5K-1/N5K-2 interfaces (Task 2.1) should already permit VLAN 10 and 11 on both physical interfaces — a VLAN Group pin doesn't need a matching restriction on the N5K allowed-list the way a hard-segregation design would, since both VLANs are legitimately allowed on both trunks:
 
-```text
-! N5K-1/N5K-2 — both VLANs are legitimately allowed on both interfaces;
-! the VLAN Group pin only affects which uplink the FI/UCSM side prefers as primary
-interface Ethernet1/1
-  switchport trunk allowed vlan 10,11
-interface Ethernet1/2
-  switchport trunk allowed vlan 10,11
-```
+??? "Commands"
+    ```text
+    ! N5K-1/N5K-2 — both VLANs are legitimately allowed on both interfaces;
+    ! the VLAN Group pin only affects which uplink the FI/UCSM side prefers as primary
+    interface Ethernet1/1
+      switchport trunk allowed vlan 10,11
+    interface Ethernet1/2
+      switchport trunk allowed vlan 10,11
+    ```
 
 **Verify:** **LAN > LAN Cloud > VLAN Groups**, confirm each group's member VLAN and its pinned uplink; cross-check with `show interface trunk` on N5K-1/N5K-2 that VLAN 10 and 11 both appear on both physical interfaces — that's expected here, unlike a hard-segregated design.
 

--- a/docs/ucs-san/04-port-modes.md
+++ b/docs/ucs-san/04-port-modes.md
@@ -25,16 +25,18 @@ If your FI or N5K-3/N5K-4 use unified/flex ports (e.g. 6248UP, 5548UP/5596UP), c
 - **FI:** Equipment > Fixed Module (or Expansion Module) > **Configure Unified Ports**. The reboot scope depends on which module you change: a change on the **fixed module reboots the entire Fabric Interconnect** — roughly an 8-minute outage for all data traffic through that FI — while a change on an **expansion module only reboots that module**, about a 1-minute interruption limited to its own ports. Plan a maintenance window sized for the fixed-module case if that's what you're touching.
 - **N5K:**
 
-```text
-slot 1 port 1-4 type fc
-```
+??? "Commands"
+    ```text
+    slot 1 port 1-4 type fc
+    ```
 
 then `copy running-config startup-config` and reload the module. Confirm with:
 
-```text
-show port-resource module 1
-show interface brief
-```
+??? "Commands"
+    ```text
+    show port-resource module 1
+    show interface brief
+    ```
 
 !!! question "Check yourself"
     Why do unified port conversions require a reload, while simply changing an existing FC port from F to E mode does not? And why is converting a few ports on an FI's fixed module a bigger deal, operationally, than the same conversion on an expansion module?

--- a/docs/ucs-san/05-fc-fcoe.md
+++ b/docs/ucs-san/05-fc-fcoe.md
@@ -35,36 +35,38 @@ Confirm (from Module 1) each service profile has all four vHBAs correctly placed
 
 This is an **alternative to Task 2.3's native-FC F-port config**, not an addition to it — use whichever matches your actual uplink type. If the FI-to-N5K SAN uplink is FCoE rather than native FC, confirm FIP snooping and the virtual Fibre Channel interfaces on the N5K side — one `vfc` per VSAN on that fabric, both bound to the same underlying Ethernet trunk:
 
-```text
-feature fcoe
-vlan 1000
-  fcoe vsan 100
-vlan 1001
-  fcoe vsan 101
-! the underlying Ethernet interface (or port-channel) must already be a trunk
-! carrying both FCoE VLANs before you bind a vfc to it — this is separate from
-! the LAN-side trunk config in Task 2.1, even if it's the same physical interface
-interface Ethernet1/1
-  switchport mode trunk
-  switchport trunk allowed vlan 1000,1001
-interface vfc1
-  bind interface Ethernet1/1
-  no shutdown
-interface vfc2
-  bind interface Ethernet1/1
-  no shutdown
-show vfc
-show fcoe database
-```
+??? "Commands"
+    ```text
+    feature fcoe
+    vlan 1000
+      fcoe vsan 100
+    vlan 1001
+      fcoe vsan 101
+    ! the underlying Ethernet interface (or port-channel) must already be a trunk
+    ! carrying both FCoE VLANs before you bind a vfc to it — this is separate from
+    ! the LAN-side trunk config in Task 2.1, even if it's the same physical interface
+    interface Ethernet1/1
+      switchport mode trunk
+      switchport trunk allowed vlan 1000,1001
+    interface vfc1
+      bind interface Ethernet1/1
+      no shutdown
+    interface vfc2
+      bind interface Ethernet1/1
+      no shutdown
+    show vfc
+    show fcoe database
+    ```
 
 (Fabric B mirrors this on N5K-4 with VLAN 2000/VSAN 200 and VLAN 2001/VSAN 201.)
 
 **Verify (either flavor):**
 
-```text
-show flogi database
-show npv flogi-table      ! run from the FI's NX-OS shell: connect nxos {a|b}, then this command
-```
+??? "Commands"
+    ```text
+    show flogi database
+    show npv flogi-table      ! run from the FI's NX-OS shell: connect nxos {a|b}, then this command
+    ```
 
 Each associated blade's vHBA should FLOGI in with a WWPN drawn from your Module 1 WWPN pool.
 

--- a/docs/ucs-san/06-zoning.md
+++ b/docs/ucs-san/06-zoning.md
@@ -9,14 +9,15 @@
 
 On N5K-3, one device-alias per vHBA you're zoning plus one per storage target port. This lab has two VSANs on Fabric A (boot + data), so there are two blade-side aliases and — if the array uses a different target port per LUN — potentially two storage-side aliases as well:
 
-```text
-device-alias database
-  device-alias name Blade01-hba0 pwwn 20:00:00:25:b5:0a:00:01    ! vHBA0, VSAN 100 (boot)
-  device-alias name Blade01-hba2 pwwn 20:00:00:25:b5:0a:00:03    ! vHBA2, VSAN 101 (data)
-  device-alias name Storage-fa-boot pwwn 50:0a:09:81:88:9a:6b:c0
-  device-alias name Storage-fa-data pwwn 50:0a:09:82:88:9a:6b:c0
-device-alias commit
-```
+??? "Commands"
+    ```text
+    device-alias database
+      device-alias name Blade01-hba0 pwwn 20:00:00:25:b5:0a:00:01    ! vHBA0, VSAN 100 (boot)
+      device-alias name Blade01-hba2 pwwn 20:00:00:25:b5:0a:00:03    ! vHBA2, VSAN 101 (data)
+      device-alias name Storage-fa-boot pwwn 50:0a:09:81:88:9a:6b:c0
+      device-alias name Storage-fa-data pwwn 50:0a:09:82:88:9a:6b:c0
+    device-alias commit
+    ```
 
 Pull the actual WWPNs from `show flogi database` (blade side) and the array's documentation or `show fcns database` (storage side) rather than guessing. Repeat the equivalent alias set on N5K-4 for Fabric B (VSAN 200 boot, VSAN 201 data), using `-fb` names.
 
@@ -24,38 +25,40 @@ Pull the actual WWPNs from `show flogi database` (blade side) and the array's do
 
 Single-initiator, single-target zoning is the standard, exam-expected pattern. Each VSAN gets its own zone and its own zoneset — a zone is scoped to exactly one VSAN, so the boot zone and the data zone can't share one even though they're on the same physical switch:
 
-```text
-! VSAN 100 — boot path
-zone name Blade01-Boot-to-Storage-fa vsan 100
-  member device-alias Blade01-hba0
-  member device-alias Storage-fa-boot
+??? "Commands"
+    ```text
+    ! VSAN 100 — boot path
+    zone name Blade01-Boot-to-Storage-fa vsan 100
+      member device-alias Blade01-hba0
+      member device-alias Storage-fa-boot
 
-zoneset name ZS-Fabric-A-Boot vsan 100
-  member Blade01-Boot-to-Storage-fa
+    zoneset name ZS-Fabric-A-Boot vsan 100
+      member Blade01-Boot-to-Storage-fa
 
-zoneset activate name ZS-Fabric-A-Boot vsan 100
+    zoneset activate name ZS-Fabric-A-Boot vsan 100
 
-! VSAN 101 — data path
-zone name Blade01-Data-to-Storage-fa vsan 101
-  member device-alias Blade01-hba2
-  member device-alias Storage-fa-data
+    ! VSAN 101 — data path
+    zone name Blade01-Data-to-Storage-fa vsan 101
+      member device-alias Blade01-hba2
+      member device-alias Storage-fa-data
 
-zoneset name ZS-Fabric-A-Data vsan 101
-  member Blade01-Data-to-Storage-fa
+    zoneset name ZS-Fabric-A-Data vsan 101
+      member Blade01-Data-to-Storage-fa
 
-zoneset activate name ZS-Fabric-A-Data vsan 101
-```
+    zoneset activate name ZS-Fabric-A-Data vsan 101
+    ```
 
 Repeat both pairs with fabric-B naming (`-fb`) on N5K-4, under VSAN 200 (boot) and VSAN 201 (data).
 
 ## 6.3 Task 5.3 — Verify
 
-```text
-show zoneset active vsan 100
-show zoneset active vsan 101
-show zone name Blade01-Boot-to-Storage-fa vsan 100
-show device-alias database
-```
+??? "Commands"
+    ```text
+    show zoneset active vsan 100
+    show zoneset active vsan 101
+    show zone name Blade01-Boot-to-Storage-fa vsan 100
+    show device-alias database
+    ```
 
 Confirm the storage array's LUN masking (on the array side) presents each LUN to exactly the WWPNs you zoned for it — zoning and masking are two independent controls that must both agree, and this now matters twice (once per VSAN) instead of once.
 

--- a/docs/ucs-san/07-npv-npiv.md
+++ b/docs/ucs-san/07-npv-npiv.md
@@ -12,10 +12,11 @@
 
 `show npv status` is a real command, but it reports whether *this device* is acting as an NPV edge — it's what you run on the FI (Task 6.2), not on the core switch. On N5K-3/N5K-4 (which just has the NPIV *feature* enabled, not NPV mode), confirm the feature is on and prove it's working by checking that the fabric actually accepted multiple FCIDs over a single F port:
 
-```text
-show feature | include npiv
-show flogi database vsan 100
-```
+??? "Commands"
+    ```text
+    show feature | include npiv
+    show flogi database vsan 100
+    ```
 
 Multiple pWWN entries all logged in via the *same* physical interface is the real proof NPIV is functioning — a feature flag being "enabled" doesn't by itself confirm anything actually used it yet.
 
@@ -23,19 +24,21 @@ Multiple pWWN entries all logged in via the *same* physical interface is the rea
 
 The FI itself, in End Host Mode, is functioning as the NPV device. From the FI's NX-OS-like CLI:
 
-```text
-show npv flogi-table
-show npv internal info
-```
+??? "Commands"
+    ```text
+    show npv flogi-table
+    show npv internal info
+    ```
 
 You should see one row per downstream vHBA, all funneling through the same uplink FCID.
 
 ## 7.4 Task 6.3 — Verify at the Core
 
-```text
-show flogi database vsan 100
-show fcns database vsan 100
-```
+??? "Commands"
+    ```text
+    show flogi database vsan 100
+    show fcns database vsan 100
+    ```
 
 Confirm multiple pWWNs (one per blade vHBA) all logged in via the *same* interface (the FI uplink) — this is NPIV in action, and it's the single clearest piece of exam-relevant evidence you can screenshot for your own notes.
 

--- a/docs/ucs-san/08-trunking.md
+++ b/docs/ucs-san/08-trunking.md
@@ -6,12 +6,13 @@
 
 On the F-port (or F-port-channel, see Module 8) between N5K-3 and FI-A, this lab already carries two VSANs (100 and 101) over the same physical uplink — you configured this back in Module 2, Task 2.3, so this is where you go verify it, not build it fresh:
 
-```text
-interface fc1/1
-  switchport mode F
-  switchport trunk mode on
-  switchport trunk allowed vsan 100,101
-```
+??? "Commands"
+    ```text
+    interface fc1/1
+      switchport mode F
+      switchport trunk mode on
+      switchport trunk allowed vsan 100,101
+    ```
 
 That `100,101` is exactly the scenario a single-VSAN design never has to think about: if you needed to add a third VSAN later, you'd extend the list rather than replace it — `switchport trunk allowed vsan add 300` — since replacing it outright would silently drop the VSANs you left out.
 
@@ -19,19 +20,20 @@ That `100,101` is exactly the scenario a single-VSAN design never has to think a
 
 Already touched in Module 2.1 — revisit it here specifically for trunk *negotiation and allowed-list hygiene*. Each N5K uplink still only carries its own fabric's pair — this is a check, not a widening of the allowed list from Task 2.1:
 
-```text
-! Toward FI-A
-interface Ethernet1/1
-  switchport mode trunk
-  switchport trunk allowed vlan 10,11
-  spanning-tree port type edge trunk   ! if this faces an FI, not another switch
+??? "Commands"
+    ```text
+    ! Toward FI-A
+    interface Ethernet1/1
+      switchport mode trunk
+      switchport trunk allowed vlan 10,11
+      spanning-tree port type edge trunk   ! if this faces an FI, not another switch
 
-! Toward FI-B
-interface Ethernet1/2
-  switchport mode trunk
-  switchport trunk allowed vlan 20,21
-  spanning-tree port type edge trunk
-```
+    ! Toward FI-B
+    interface Ethernet1/2
+      switchport mode trunk
+      switchport trunk allowed vlan 20,21
+      spanning-tree port type edge trunk
+    ```
 
 ## 8.3 Task 7.3 — FI-Side Trunk Definitions
 
@@ -39,11 +41,12 @@ On the FI: **LAN > VLANs** and **SAN > VSANs** must both explicitly list every I
 
 **Verify:**
 
-```text
-show interface trunk
-show vsan
-show vlan brief
-```
+??? "Commands"
+    ```text
+    show interface trunk
+    show vsan
+    show vlan brief
+    ```
 
 !!! question "Check yourself"
     On the LAN side, what NX-OS feature protects a trunk to an FI (a non-switch, non-STP-speaking device) from accidentally being blocked by spanning tree, and why is that setting safe specifically because the far end is an FI?
@@ -57,25 +60,28 @@ show vlan brief
 3. **Confirm those VLANs exist and are assigned to the uplink in UCSM.** **LAN > LAN Cloud > VLANs** — confirm VLAN 30/40 are defined, and check that they're assigned to the uplink port/port-channel from Task 2.1.
 4. **Check the upstream N5K-1/N5K-2 allowed-list on the specific interface facing that FI:**
 
-    ```text
-    show vlan
-    show interface trunk
-    ```
+    ??? "Commands"
+        ```text
+        show vlan
+        show interface trunk
+        ```
 
     If VLAN 30 and 40 exist switch-wide in `show vlan` but are missing from that interface's "Vlans Allowed on Trunk" list in `show interface trunk`, you've found it — the FI is willing to pass VLAN 30/40 frames, but the upstream N5K interface is silently dropping them because its allowed-list doesn't include those IDs. Everything on VLAN 10 keeps working over the exact same physical link, which is why the fault looks so selective.
 
 5. **Fix the allowed list on the affected interface:**
 
-    ```text
-    interface Ethernet1/1
-      switchport trunk allowed vlan add 30,40
-    ```
+    ??? "Commands"
+        ```text
+        interface Ethernet1/1
+          switchport trunk allowed vlan add 30,40
+        ```
 
 6. **Verify and confirm recovery:**
 
-    ```text
-    show interface trunk
-    ```
+    ??? "Commands"
+        ```text
+        show interface trunk
+        ```
 
     Confirm VLAN 30 and 40 now appear in that interface's allowed list, then confirm from the blade side that it obtains a DHCP lease and can reach the default gateway.
 

--- a/docs/ucs-san/09-portchannel.md
+++ b/docs/ucs-san/09-portchannel.md
@@ -6,16 +6,17 @@
 
 If N5K-1/N5K-2 form a vPC domain toward each FI, the peer-keepalive link must already be up before the peer-link (port-channel) can form — configure it first, and note it needs its own routed source/destination pair (commonly the mgmt0 VRF), separate from the peer-link data path:
 
-```text
-! On both N5K-1 and N5K-2
-feature vpc
-vpc domain 1
-  peer-keepalive destination <peer-mgmt-ip> source <this-switch-mgmt-ip> vrf management
-interface port-channel10
-  vpc 10
-interface Ethernet1/1
-  channel-group 10 mode active
-```
+??? "Commands"
+    ```text
+    ! On both N5K-1 and N5K-2
+    feature vpc
+    vpc domain 1
+      peer-keepalive destination <peer-mgmt-ip> source <this-switch-mgmt-ip> vrf management
+    interface port-channel10
+      vpc 10
+    interface Ethernet1/1
+      channel-group 10 mode active
+    ```
 
 On the FI side, bundle the corresponding uplink ports into a **Port Channel** under **LAN > LAN Cloud > Fabric A > Port Channels**.
 
@@ -23,23 +24,25 @@ On the FI side, bundle the corresponding uplink ports into a **Port Channel** un
 
 If more than one FC/FCoE link exists between an FI and its N5K, bundle them into a **SAN Port Channel**. Carry both of that fabric's VSANs on the port channel, same as you did on the single F port back in Module 2, Task 2.3:
 
-```text
-interface fc1/1-2
-  channel-group 1 force
-interface san-port-channel 1
-  switchport mode F
-  switchport trunk allowed vsan 100,101
-```
+??? "Commands"
+    ```text
+    interface fc1/1-2
+      channel-group 1 force
+    interface san-port-channel 1
+      switchport mode F
+      switchport trunk allowed vsan 100,101
+    ```
 
 On the FI: **SAN > SAN Cloud > Fabric A > FC Port Channels**, add the member uplinks.
 
 ## 9.3 Task 8.3 — Verify
 
-```text
-show port-channel summary
-show interface port-channel10
-show san-port-channel summary
-```
+??? "Commands"
+    ```text
+    show port-channel summary
+    show interface port-channel10
+    show san-port-channel summary
+    ```
 
 Confirm all members show `(P)` (up, in port channel) — a member stuck in `(I)` (individual) or `(D)` (down) means a parameter mismatch (speed, mode, or allowed VSAN/VLAN list) between the two ends.
 

--- a/docs/ucs-san/10-load-balancing.md
+++ b/docs/ucs-san/10-load-balancing.md
@@ -4,10 +4,11 @@
 
 ## 10.1 Task 9.1 — Ethernet Port-Channel Hashing
 
-```text
-port-channel load-balance ethernet source-dest-port
-show port-channel load-balance
-```
+??? "Commands"
+    ```text
+    port-channel load-balance ethernet source-dest-port
+    show port-channel load-balance
+    ```
 
 (This is Nexus 5000 syntax — the `ethernet <keyword>` form. Nexus 7000/9000 platforms use a different keyword style, e.g. `src-dst ip-l4port`; don't mix the two.)
 
@@ -17,9 +18,10 @@ Pick a hash that includes L4 port when traffic is mostly IP flows between the sa
 
 FC port channels load-balance per-exchange by default (OX_ID-based), which is almost always correct; per-flogi is available for edge cases where in-order delivery across the whole channel matters more than distribution. Check current mode:
 
-```text
-show san-port-channel summary
-```
+??? "Commands"
+    ```text
+    show san-port-channel summary
+    ```
 
 ## 10.3 Task 9.3 — UCS-Side Pinning and Failover
 

--- a/docs/ucs-san/13-appendix.md
+++ b/docs/ucs-san/13-appendix.md
@@ -2,63 +2,66 @@
 
 ## A.1 NX-OS — SAN (N5K-3 / N5K-4)
 
-```text
-! feature npiv        — pod baseline, already enabled; confirm with `show feature | include npiv` (Section 1.1), don't reconfigure
-feature fcoe
-vsan database
-  vsan 100
-  vsan 101
-interface fc1/1
-  switchport mode F
-  switchport trunk allowed vsan 100,101
-device-alias database
-  device-alias name <name> pwwn <wwpn>
-device-alias commit
-zone name <zone> vsan 100
-  member device-alias <name>
-zoneset name <zoneset> vsan 100
-  member <zone>
-zoneset activate name <zoneset> vsan 100
-show flogi database
-show fcns database vsan 100
-show fcns database vsan 101
-show zoneset active vsan 100
-show zoneset active vsan 101
-show feature | include npiv
-show vsan
-```
+??? "Commands"
+    ```text
+    ! feature npiv        — pod baseline, already enabled; confirm with `show feature | include npiv` (Section 1.1), don't reconfigure
+    feature fcoe
+    vsan database
+      vsan 100
+      vsan 101
+    interface fc1/1
+      switchport mode F
+      switchport trunk allowed vsan 100,101
+    device-alias database
+      device-alias name <name> pwwn <wwpn>
+    device-alias commit
+    zone name <zone> vsan 100
+      member device-alias <name>
+    zoneset name <zoneset> vsan 100
+      member <zone>
+    zoneset activate name <zoneset> vsan 100
+    show flogi database
+    show fcns database vsan 100
+    show fcns database vsan 101
+    show zoneset active vsan 100
+    show zoneset active vsan 101
+    show feature | include npiv
+    show vsan
+    ```
 
 (N5K-4 mirrors this with VSAN 200/201 for Fabric B.)
 
 ## A.2 NX-OS — LAN (N5K-1 / N5K-2)
 
-```text
-feature vpc
-vpc domain 1
-  peer-keepalive destination <ip> source <ip> vrf management
-interface port-channel10
-  vpc 10
-interface Ethernet1/1
-  switchport mode trunk
-  switchport trunk allowed vlan 10,11,1000
-  channel-group 10 mode active
-show port-channel summary
-show interface trunk
-show vpc brief
-```
+??? "Commands"
+    ```text
+    feature vpc
+    vpc domain 1
+      peer-keepalive destination <ip> source <ip> vrf management
+    interface port-channel10
+      vpc 10
+    interface Ethernet1/1
+      switchport mode trunk
+      switchport trunk allowed vlan 10,11,1000
+      channel-group 10 mode active
+    show port-channel summary
+    show interface trunk
+    show vpc brief
+    ```
 
 (The Fabric B-facing interface carries the same shared VLAN 10,11 pair, plus its own FCoE VLAN 2000 in place of Fabric A's 1000 — the LAN VLANs are common to both fabric uplinks; only the FCoE VLAN tied to each fabric's VSANs differs.)
 
 ## A.3 UCS Manager (GUI paths)
 
-```text
-Equipment > Fabric Interconnects > Fixed Module > [Ethernet | FC] Ports   (port roles)
-Equipment > Configure Unified Ports                                       (personality conversion)
-LAN > LAN Cloud > Fabric A/B > Port Channels                              (Ethernet uplink bundling)
-SAN > SAN Cloud > Fabric A/B > VSANs | FC Port Channels                   (SAN uplink + trunking)
-SAN > SAN Cloud > Fabric A/B > Set FC Switching Mode                      (End Host vs Switch Mode)
-Servers > Pools | Policies | Service Profile Templates                    (Module 1 constructs)
-```
+??? "Commands"
+    ```text
+    Equipment > Fabric Interconnects > Fixed Module > [Ethernet | FC] Ports   (port roles)
+    Equipment > Configure Unified Ports                                       (personality conversion)
+    LAN > LAN Cloud > Fabric A/B > Port Channels                              (Ethernet uplink bundling)
+    SAN > SAN Cloud > Fabric A/B > VSANs | FC Port Channels                   (SAN uplink + trunking)
+    SAN > SAN Cloud > Fabric A/B > Set FC Switching Mode                      (End Host vs Switch Mode)
+    Servers > Pools | Policies | Service Profile Templates                    (Module 1 constructs)
+    ```
 
 ---
 


### PR DESCRIPTION
## Summary
All 37 command/verify code blocks across the UCS & SAN pages are now wrapped in collapsible admonitions (`??? "Commands"`) instead of always-visible fenced code blocks. Matches the collapse/expand behavior the original single-file guide had (its custom `<details class="cmdbox">` markup with Show all/Hide all buttons), now using Material's native collapsible-details support — collapsed by default, click to expand, no custom JS needed.

## Test plan
- [x] `mkdocs build --strict` passes with no warnings
- [x] Verified rendered output produces `<details><summary>Commands</summary>...</details>` for every converted block, including the nested-list case in Module 7 (Task 7.4)
- [x] Confirmed blocks render collapsed by default (no `open` attribute)