### PR TITLE
UCS & SAN: technical corrections and nav restructuring

### DIFF
--- a/docs/ucs-san/00-overview.md
+++ b/docs/ucs-san/00-overview.md
@@ -52,7 +52,9 @@ Keep these consistent across every module so zoning, trunking, and verification 
 | vHBAs | vHBA0 → VSAN 100 (boot), vHBA2 → VSAN 101 (data) | vHBA1 → VSAN 200 (boot), vHBA3 → VSAN 201 (data) |
 | UCSM domain | Fabric A = Primary FI | Fabric B = Subordinate FI |
 | Device alias suffix | `-fa` | `-fb` |
-| VLAN Group name | `VG-Data` (VLAN 10) — pinned primary to FI-A uplink | `VG-Mgmt` (VLAN 11) — pinned primary to FI-B uplink |
+| VLAN Group name | `VG-Data` (VLAN 10) — conceptual example, see Module 2.4* | `VG-Mgmt` (VLAN 11) — conceptual example, see Module 2.4* |
+
+\* Both VLANs stay shared and trunked to both fabrics in this lab's actual design — see Module 2.4 for why an actual VLAN Group association isn't built against this lab's own redundant uplinks.
 
 !!! note "Why VSANs split into Boot/Data but VLANs don't"
     A single vHBA can only ever belong to one VSAN, so accessing a second VSAN on the same fabric means a second vHBA, not a wider allowed-list on the first one. That's the opposite of how one Ethernet vNIC can trunk several VLANs at once — worth having straight before Module 1's templates, since it's a common point of confusion between the LAN and SAN sides.

--- a/docs/ucs-san/02-compute-policies.md
+++ b/docs/ucs-san/02-compute-policies.md
@@ -271,22 +271,20 @@ In the GUI: **Servers > Service Profiles**, confirm Assoc State = `associated`, 
 !!! question "Check yourself"
     What happens to already-associated profiles if you edit an *updating* vNIC template's VLAN list versus editing an *initial* template? Be able to explain the propagation difference out loud.
 
-### Worked Example: Unbinding a Service Profile to Make a One-Off Change
+??? "📚 Worked Example — Unbinding a Service Profile to Make a One-Off Change"
+    **Scenario:** `SPT-ESX-SANBoot` is an **Updating Template** (Task 1.5, by design), so every profile generated from it in this task — `Blade01`, `Blade02`, and so on — stays permanently bound to it: change the template later and every bound profile picks up that change automatically. Now suppose you need to make a change on **`Blade02` only** — a one-off BIOS tweak while you diagnose something, a different boot LUN ID for a single test blade, whatever — without that change propagating to `Blade01` and every other profile sharing the template. A bound profile won't let you do this directly.
 
-**Scenario:** `SPT-ESX-SANBoot` is an **Updating Template** (Task 1.5, by design), so every profile generated from it in this task — `Blade01`, `Blade02`, and so on — stays permanently bound to it: change the template later and every bound profile picks up that change automatically. Now suppose you need to make a change on **`Blade02` only** — a one-off BIOS tweak while you diagnose something, a different boot LUN ID for a single test blade, whatever — without that change propagating to `Blade01` and every other profile sharing the template. A bound profile won't let you do this directly.
+    **Why the direct edit doesn't work:** Cisco's own documentation is explicit about what binding actually means: *"you can only change the configuration of a bound service profile through the associated template."* While a profile is bound, UCSM treats the template as the single source of truth — if you try to edit a template-controlled field directly on the bound profile, either the field is not editable, or UCSM reconfigures the profile back to match the template the next time it reconciles. Binding isn't a one-time copy; it's a standing link.
 
-**Why the direct edit doesn't work:** Cisco's own documentation is explicit about what binding actually means: *"you can only change the configuration of a bound service profile through the associated template."* While a profile is bound, UCSM treats the template as the single source of truth — if you try to edit a template-controlled field directly on the bound profile, either the field is not editable, or UCSM reconfigures the profile back to match the template the next time it reconciles. Binding isn't a one-time copy; it's a standing link.
+    **Fix — unbind the one profile you need to diverge:**
 
-**Fix — unbind the one profile you need to diverge:**
+    1. **Servers > Service Profiles > [org] > `Blade02`.**
+    2. **Work pane > General tab.**
+    3. **Actions area > Unbind from the Template.**
+    4. Confirm **Yes** on the dialog.
 
-1. **Servers > Service Profiles > [org] > `Blade02`.**
-2. **Work pane > General tab.**
-3. **Actions area > Unbind from the Template.**
-4. Confirm **Yes** on the dialog.
+    **CLI equivalent**, for the same result:
 
-**CLI equivalent**, for the same result:
-
-??? "Commands"
     ```text
     scope org
     scope service-profile Blade02
@@ -294,7 +292,7 @@ In the GUI: **Servers > Service Profiles**, confirm Assoc State = `associated`, 
     commit-buffer
     ```
 
-**What actually changes:** unbinding only removes the link to the parent template — it does **not** revert or clear anything. `Blade02` keeps every setting and resource it already had (VLANs, VSANs, boot policy, pools, everything from the last time it matched the template) and simply becomes a **static, independent service profile** from that point on. You can now edit `Blade02` directly, and — just as important — the reverse is now also true: if you go back and change `SPT-ESX-SANBoot` itself, `Blade02` no longer picks up that change, while `Blade01` (still bound) does. That asymmetry is the actual trade-off, not a side effect: unbinding buys per-profile flexibility at the cost of that one profile falling out of the template's future updates until you explicitly **Bind to a Template** again (same General tab, **Actions > Bind to a Template**).
+    **What actually changes:** unbinding only removes the link to the parent template — it does **not** revert or clear anything. `Blade02` keeps every setting and resource it already had (VLANs, VSANs, boot policy, pools, everything from the last time it matched the template) and simply becomes a **static, independent service profile** from that point on. You can now edit `Blade02` directly, and — just as important — the reverse is now also true: if you go back and change `SPT-ESX-SANBoot` itself, `Blade02` no longer picks up that change, while `Blade01` (still bound) does. That asymmetry is the actual trade-off, not a side effect: unbinding buys per-profile flexibility at the cost of that one profile falling out of the template's future updates until you explicitly **Bind to a Template** again (same General tab, **Actions > Bind to a Template**).
 
 **Verify:** **Servers > Service Profiles > `Blade02` > General**, confirm the template reference field is now empty and the fields you needed to change are editable directly.
 

--- a/docs/ucs-san/03-uplinks.md
+++ b/docs/ucs-san/03-uplinks.md
@@ -2,6 +2,16 @@
 
 **Objective:** get traffic off the Fabric Interconnects and onto both the LAN switches and the SAN switches, correctly typed as uplink ports.
 
+Cisco documents three distinct Ethernet uplink roles on a Fabric Interconnect — don't treat them as interchangeable, since UCSM configures and licenses each differently:[^role]
+
+| Role | Carries | Used in this module for |
+|---|---|---|
+| **Ethernet uplink** | LAN/Ethernet traffic only | Task 2.1, toward N5K-1/N5K-2 |
+| **FCoE uplink** | Fibre Channel encapsulated in Ethernet, toward an upstream FCoE-capable switch | Task 4.5's alternative FCoE path (`05-fc-fcoe.md`), not this pod's default |
+| **Unified uplink** | Both Ethernet and FC/FCoE traffic on one physical port | Not used in this lab's topology — its N5K-1/2 (LAN) and N5K-3/4 (SAN) roles are already split onto separate physical uplinks |
+
+[^role]: [Cisco UCS Manager Network Management Guide, Release 6.0 — LAN Ports and Port Channels](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/ucs-manager/GUI-User-Guides/Network-Mgmt/4-2/b_UCSM_Network_Mgmt_Guide_4_2/b_UCSM_Network_Mgmt_Guide_chapter_01000.html)
+
 ## 3.1 Task 2.1 — Ethernet (LAN) Uplinks
 
 ![LAN aspect of Nexus DC-1: N5K-1/N5K-2, FI-A/FI-B, and Host highlighted](../assets/topology-lan.png)
@@ -85,25 +95,43 @@ You should see the FI's WWPN(s) FLOGI into the fabric as soon as the link and VS
 
 ## 3.4 Task 2.4 — VLAN Groups
 
-**Objective:** organize related VLANs into a named, reusable object and pin that whole set to a preferred uplink, instead of managing each VLAN's uplink assignment one at a time.
+**Objective:** understand VLAN Groups for what Cisco actually documents them as — a mechanism for controlling *which uplinks carry which VLANs*, not a load-balancing or preferred-path tool.
 
-A **VLAN Group** (UCSM: **LAN > LAN Cloud > VLAN Groups**) is a container of VLANs that can be assigned to one or more uplink ports or uplink port channels as a single unit. It doesn't replace VLANs or trunking — it's a management and traffic-engineering layer on top of them. Since VLAN 10 and 11 are both shared and trunked to both fabrics' uplinks for redundancy (Task 2.1), a VLAN Group here isn't used to keep one VLAN off a given uplink — it's used to give each VLAN a *preferred, primary* path, so normal-condition traffic splits predictably across the two uplinks instead of being left to hash unpredictably.
+A **VLAN Group** (UCSM: **LAN > LAN Cloud > VLAN Groups**) associates a set of VLANs with specific uplink Ethernet ports or uplink port channels. Cisco's own documented behavior is explicit and important to get right: once a VLAN Group is associated with a chosen set of uplinks, **any uplink not selected for that association stops supporting the VLANs in that group.** This is a restriction, not a preference — there is no "primary path with failover to an unselected uplink" behavior built into the VLAN Group construct itself.[^1]
 
-1. **Create the groups:** a VLAN Group can only contain VLANs that already exist as objects under **LAN > LAN Cloud > VLANs** — Module 1, Task 1.1 already created both you need, so this task is purely about grouping and pinning. Right-click **VLAN Groups > Create VLAN Group** twice: `VG-Data` with member VLAN 10, and `VG-Mgmt` with member VLAN 11.
-2. **Pin each group to a preferred uplink:** in the same wizard (or by editing the group afterward), assign `VG-Data` to the uplink port/port-channel facing FI-A as its primary path, and `VG-Mgmt` to the uplink facing FI-B as its primary path, under **LAN Uplink Ports** / **Port Channels**. This is a preference, not an exclusion — both VLANs stay trunked on both uplinks (Task 2.1), so either one still fails over to the other uplink if its pinned path goes down.
-3. **Match the N5K side:** the trunk `allowed vlan` list on both N5K-1/N5K-2 interfaces (Task 2.1) should already permit VLAN 10 and 11 on both physical interfaces — a VLAN Group pin doesn't need a matching restriction on the N5K allowed-list the way a hard-segregation design would, since both VLANs are legitimately allowed on both trunks:
+Because this lab's own VLAN 10/11 are deliberately shared and trunked identically to both Fabric A and Fabric B uplinks (§0.3, Task 2.1) — not split per fabric — actually associating a VLAN Group with only one fabric's uplink here would remove that VLAN from the other fabric's uplink entirely, which is the opposite of this lab's redundancy design. So this task does **not** build a VLAN Group against this lab's real uplinks. Instead:
 
-??? "Commands"
+??? "🔍 Deep Dive — Upstream Disjoint Layer-2 Networks"
+    VLAN Groups exist for topologies where the FI's two fabrics genuinely face **different, disjoint upstream Layer-2 networks** — not the shared/redundant design this lab uses. Conceptually:
+
     ```text
-    ! N5K-1/N5K-2 — both VLANs are legitimately allowed on both interfaces;
-    ! the VLAN Group pin only affects which uplink the FI/UCSM side prefers as primary
-    interface Ethernet1/1
-      switchport trunk allowed vlan 10,11
-    interface Ethernet1/2
-      switchport trunk allowed vlan 10,11
+    Upstream Network A
+          |
+        N5K-A
+          |
+     FI uplink A
+          |
+     VLANs assigned to Network A
     ```
 
-**Verify:** **LAN > LAN Cloud > VLAN Groups**, confirm each group's member VLAN and its pinned uplink; cross-check with `show interface trunk` on N5K-1/N5K-2 that VLAN 10 and 11 both appear on both physical interfaces — that's expected here, unlike a hard-segregated design.
+    ```text
+    Upstream Network B
+          |
+        N5K-B
+          |
+     FI uplink B
+          |
+     VLANs assigned to Network B
+    ```
+
+    Here, VLAN Groups ensure the VLANs that only exist on Network A's side are associated only with FI uplink A, and likewise for Network B — because Network A and Network B don't share a Layer-2 domain, a VLAN valid on one has no business appearing on the other's uplink at all. This is what Cisco calls disjoint Layer-2 networking, and it's the actual production use case VLAN Groups solve.[^2]
+
+    This lab's topology is **not** disjoint Layer-2 — N5K-1 and N5K-2 both sit in the same shared LAN domain, and VLAN 10/11 are intentionally common to both. If you want hands-on practice with a real VLAN Group association, you'd need a second, genuinely separate upstream network to point one fabric's uplink at — not something to build against this pod's actual N5K-1/N5K-2 pair.
+
+**Verify (conceptual only, given the above):** **LAN > LAN Cloud > VLAN Groups** — if a VLAN Group is ever associated with a subset of this lab's uplinks, confirm on the N5K side with `show interface trunk` that the *unselected* uplink's allowed-VLAN behavior for that group's VLANs actually reflects the restriction — don't assume the VLAN still passes there.
 
 !!! question "Check yourself"
-    If VLAN Group pinning only sets a *preferred* path rather than an exclusive one, what would you actually expect to change if you shut down `VG-Data`'s pinned uplink — and how would you confirm VLAN 10's traffic failed over rather than simply stopped?
+    If VLAN Group `VG-Data` (VLAN 10) is associated only with the FI-A-facing uplink, what happens to VLAN 10 traffic that would otherwise have used the FI-B-facing uplink — does it fail over, or does that uplink simply stop supporting VLAN 10? What does that imply about using VLAN Groups on a fabric pair that's supposed to stay redundant, like this lab's own VLAN 10/11?
+
+[^1]: [Cisco UCS Manager Network Management Guide, Release 6.0 — VLANs / VLAN Groups](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/ucs-manager/GUI-User-Guides/Network-Mgmt/4-2/b_UCSM_Network_Mgmt_Guide_4_2/b_UCSM_Network_Mgmt_Guide_chapter_0110.html): an uplink not selected for association with a VLAN Group stops supporting VLANs that are members of that group.
+[^2]: [Cisco UCS Manager Network Management Guide Using the CLI — Upstream Disjointed Layer-2 Networks](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/ucs-manager/CLI-User-Guides/Network-Mgmt/4-2/b_cli_ucsm_network_management_guide_4_2/b_CLI_UCSM_Network_Management_Guide_chapter_01010.html)

--- a/docs/ucs-san/05-fc-fcoe.md
+++ b/docs/ucs-san/05-fc-fcoe.md
@@ -3,7 +3,16 @@
 ![SAN aspect of Nexus DC-1: N5K-3/N5K-4, FI-A/FI-B, UCS-B, and Storage highlighted](../assets/topology-san.png)
 *SAN aspect of Nexus DC-1: N5K-3/N5K-4, FI-A/FI-B, UCS-B, and Storage highlighted*
 
-**Objective:** stand up the actual SAN data path through UCS Manager, in both native-FC and FCoE flavors, and prove blades can FLOGI. This is the same SAN-side path highlighted above, from the blade's vHBAs through the FIs to the SAN core switches and the array.
+**Objective:** stand up the actual SAN data path through UCS Manager and prove blades can FLOGI. This is the same SAN-side path highlighted above, from the blade's vHBAs through the FIs to the SAN core switches and the array.
+
+**This module builds one of two possible SAN uplink designs — pick the one that matches your actual FI-to-N5K cabling, not both:**
+
+- **Path A — Native Fibre Channel (this pod's default, built in Tasks 4.1–4.4 below).** The FI's FC uplink ports connect directly to N5K-3/N5K-4's F ports over native FC — no FCoE VLAN, no `vfc` binding, and no Ethernet encapsulation involved on the SAN path at all. This is the path `03-uplinks.md` §3.3 (N5K-side F ports) and this module's Tasks 4.1–4.4 assume by default.
+- **Path B — FCoE (Task 4.5, alternative).** The FI's uplink is instead an FCoE uplink (Ethernet-encapsulated FC) toward an FCoE-capable N5K, using the VLAN 1000/1001/2000/2001 ↔ VSAN mapping in §5.2 and the `vfc`/FIP-snooping config in Task 4.5. Use this only if your pod's physical uplink is actually cabled and licensed for FCoE instead of native FC.
+
+Do not configure both against the same physical uplink — they're alternative implementations of the same SAN connectivity requirement, not additive layers. Also note Cisco explicitly prohibits overlap between LAN VLAN IDs and FCoE VLAN IDs on a Fabric Interconnect: this guide's LAN VLANs (10, 11) and FCoE VLANs (1000, 1001, 2000, 2001) are chosen with that non-overlap in mind — don't reuse an FCoE VLAN ID as a LAN VLAN ID or vice versa if you change either numbering scheme.[^overlap]
+
+[^overlap]: [Cisco UCS Manager Network Management Guide, Release 6.0 — LAN Ports and Port Channels](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/ucs-manager/GUI-User-Guides/Network-Mgmt/4-2/b_UCSM_Network_Mgmt_Guide_4_2/b_UCSM_Network_Mgmt_Guide_chapter_01000.html)
 
 ## 5.1 Task 4.1 — Global FC Switching Mode
 

--- a/docs/ucs-san/08-trunking.md
+++ b/docs/ucs-san/08-trunking.md
@@ -31,7 +31,7 @@ Already touched in Module 2.1 — revisit it here specifically for trunk *negoti
     ! Toward FI-B
     interface Ethernet1/2
       switchport mode trunk
-      switchport trunk allowed vlan 20,21
+      switchport trunk allowed vlan 10,11
       spanning-tree port type edge trunk
     ```
 

--- a/docs/ucs-san/09-portchannel.md
+++ b/docs/ucs-san/09-portchannel.md
@@ -4,47 +4,138 @@
 
 ## 9.1 Task 8.1 — Ethernet Port Channel (vPC) on the LAN Side
 
-If N5K-1/N5K-2 form a vPC domain toward each FI, the peer-keepalive link must already be up before the peer-link (port-channel) can form — configure it first, and note it needs its own routed source/destination pair (commonly the mgmt0 VRF), separate from the peer-link data path:
+If N5K-1/N5K-2 form a vPC domain toward each FI, building a working vPC needs four pieces in order — feature enablement, the peer-keepalive link, the peer-link itself, and the downstream FI-facing port channel. Skipping the peer-link (the piece most often left out) leaves vPC unable to synchronize state between N5K-1 and N5K-2 at all, even if the peer-keepalive and the FI-facing port channel both look fine individually.
+
+**1 — Enable features (both N5K-1 and N5K-2):**
+
+??? "Commands"
+    ```text
+    feature vpc
+    feature lacp
+    ```
+
+**2 — vPC domain and peer-keepalive.** The peer-keepalive is a routed, out-of-band heartbeat — it must already be up before the peer-link can form, and it needs its own source/destination pair, separate from the peer-link's own data path (commonly the mgmt0 VRF, as below):
 
 ??? "Commands"
     ```text
     ! On both N5K-1 and N5K-2
-    feature vpc
     vpc domain 1
       peer-keepalive destination <peer-mgmt-ip> source <this-switch-mgmt-ip> vrf management
+    ```
+
+**Verify the keepalive is actually up before moving on** — a vPC domain with a down or misconfigured peer-keepalive will not bring vPCs into a working state no matter how correct the peer-link and downstream port channels are:
+
+??? "Commands"
+    ```text
+    show vpc peer-keepalive
+    ```
+
+**3 — Peer-link (N5K-1 ↔ N5K-2 physical links).** This is the piece a stubbed-down vPC build most often skips — the peer-link is what actually synchronizes MAC/VLAN/STP state between the two switches, and it must be a Layer-2 trunk with `spanning-tree port type network` (this enables Bridge Assurance specifically on the peer-link, which is Cisco's documented best practice for detecting a unidirectional peer-link failure) and the `vpc peer-link` role:[^peerlink]
+
+??? "Commands"
+    ```text
+    ! On both N5K-1 and N5K-2 — physical members between the two switches
+    interface Ethernet1/3-4
+      channel-group 100 mode active
+
+    interface port-channel100
+      switchport
+      switchport mode trunk
+      switchport trunk allowed vlan 10,11
+      spanning-tree port type network
+      vpc peer-link
+    ```
+
+Restrict the peer-link's allowed-VLAN list to the VLANs actually carried over vPC (10, 11 in this lab) — Cisco's own vPC best-practice guidance is to prune the peer-link to only the VLANs it needs to carry, rather than trunking everything by default.
+
+**4 — FI-facing (downstream) vPC.** This is the port channel that was already in this module before the correction — kept as-is, just now built on top of an actual peer-link instead of standing alone:
+
+??? "Commands"
+    ```text
+    ! On both N5K-1 and N5K-2
     interface port-channel10
+      switchport
+      switchport mode trunk
+      switchport trunk allowed vlan 10,11
       vpc 10
+
     interface Ethernet1/1
       channel-group 10 mode active
     ```
 
 On the FI side, bundle the corresponding uplink ports into a **Port Channel** under **LAN > LAN Cloud > Fabric A > Port Channels**.
 
-## 9.2 Task 8.2 — FC Port Channel (SAN Side)
-
-If more than one FC/FCoE link exists between an FI and its N5K, bundle them into a **SAN Port Channel**. Carry both of that fabric's VSANs on the port channel, same as you did on the single F port back in Module 2, Task 2.3:
+**Verify the whole vPC domain, not just the downstream port channel:**
 
 ??? "Commands"
     ```text
-    interface fc1/1-2
-      channel-group 1 force
-    interface san-port-channel 1
-      switchport mode F
-      switchport trunk allowed vsan 100,101
+    show vpc
+    show vpc brief
+    show port-channel summary
+    show interface port-channel100
+    show interface port-channel10
     ```
 
-On the FI: **SAN > SAN Cloud > Fabric A > FC Port Channels**, add the member uplinks.
+Confirm: peer adjacency is **peer-ok**, peer-keepalive is **alive**, the peer-link (`port-channel100`) is **up**, **vPC role** is consistent (primary/secondary), **consistency-parameters** show **success** (a mismatch here — e.g. differing MTU or trunk-allowed-VLAN lists between the two switches — is what most often blocks a vPC from coming fully up even though the peer-link itself is up), and VLAN 10/11 both show active across the FI-facing port channel.
+
+!!! warning "What a missing or inconsistent peer-link looks like"
+    Without a working peer-link, `show vpc` reports the peer-link as down and the vPC domain falls back to individual, non-synchronized forwarding on each switch — downstream port channels toward the FI may still individually pass traffic, but MAC/ARP state isn't synchronized between N5K-1 and N5K-2, which shows up as intermittent duplicate-MAC or flapping symptoms rather than a clean outage. A consistency-parameter mismatch (e.g. mismatched `switchport trunk allowed vlan` lists between the two peer-link ends) similarly leaves vPC role negotiation stuck rather than fully operational — `show vpc consistency-parameters global` isolates exactly which parameter disagrees.
+
+[^peerlink]: [Cisco Nexus Series vPC Best Practices Design Guide](https://www.cisco.com/c/dam/en/us/td/docs/switches/datacenter/sw/design/vpc_design/vpc_best_practices_design_guide.pdf) and [Cisco Nexus 5000 Series NX-OS Layer 2 Switching Configuration Guide](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/configuration/guide/cli/CLIConfigurationGuide.html) — `spanning-tree port type network` on the peer-link enables Bridge Assurance specifically on that link, and is Cisco's documented best practice for peer-link construction.
+
+## 9.2 Task 8.2 — FC Port Channel (SAN Side)
+
+If more than one FC/FCoE link exists between an FI and its N5K, bundle them into a **SAN Port Channel**. This is specifically an **F-port-channel** — the FI (acting as an NP/NPV-style device toward the core, per Module 6) forms F ports toward the N5K core switch, and the N5K side channels them together. Cisco's Nexus 5000 SAN Switching documentation is explicit that F-port-channels only support **Active-Active mode — `ON` mode is not supported.**[^fpc] Skipping the mode keyword (or leaving it at the platform default of `on`) is a real, common misconfiguration, not a cosmetic omission.
+
+**Prerequisites, in order:**
+
+1. `feature npiv` — already enabled on N5K-3/N5K-4 as this pod's confirmed baseline (Section 1.1); not reconfigured here, but it must already be live, since NPIV is what lets multiple vHBA FLOGIs ride the same physical/bundled F port.
+2. `feature fport-channel-trunk` — required specifically because this port channel needs to trunk more than one VSAN (100 and 101). Enable it before creating the SAN port channel, not after.
+
+**Build the SAN port channel with explicit Active mode:**
+
+??? "Commands"
+    ```text
+    ! N5K-3 (Fabric A core) — global config
+    feature fport-channel-trunk
+
+    ! Create the SAN port channel and set it to Active mode
+    interface san-port-channel 1
+      channel mode active
+      switchport mode F
+      switchport trunk mode on
+      switchport trunk allowed vsan 100,101
+
+    ! Add the member FC interfaces to the same channel
+    interface fc1/1-2
+      channel-group 1 force
+      no shutdown
+    ```
+
+Carry both of Fabric A's VSANs (100, 101) on the port channel, same as the single F port in Module 2, Task 2.3 — bundling members doesn't change which VSANs the fabric needs. Mirror this on N5K-4 for Fabric B (VSAN 200, 201).
+
+On the FI: **SAN > SAN Cloud > Fabric A > FC Port Channels**, add the member uplinks. The FI side of an F-port-channel toward an NPV-mode FI negotiates Active mode automatically once the N5K side is configured correctly — there's no separate FI-side mode keyword to set, but a mismatch here is exactly what produces a member stuck in individual/down state in Task 8.3's verify step.
+
+!!! note
+    `channel-group <id> force` on the FC member interfaces is the correct way to add an interface to a SAN port channel outside the auto-created default — it does not itself set the channel mode. The mode is set once, on the `san-port-channel` interface itself, via `channel mode active`.
 
 ## 9.3 Task 8.3 — Verify
+
+Proving the SAN port channel is actually operating correctly — not merely configured — needs more than a summary glance:
 
 ??? "Commands"
     ```text
     show port-channel summary
     show interface port-channel10
     show san-port-channel summary
+    show interface san-port-channel 1
+    show flogi database
+    show npv status
     ```
 
-Confirm all members show `(P)` (up, in port channel) — a member stuck in `(I)` (individual) or `(D)` (down) means a parameter mismatch (speed, mode, or allowed VSAN/VLAN list) between the two ends.
+Confirm all members show `(P)` (up, in port channel) — a member stuck in `(I)` (individual) or `(D)` (down) means a parameter mismatch (speed, mode, or allowed VSAN/VLAN list) between the two ends; for the SAN port channel specifically, a member stuck individual is the single most common symptom of a channel-mode mismatch (one end Active, the other still defaulted to `on`) rather than a cabling or VSAN problem. `show flogi database` should still show one FLOGI per vHBA on that fabric, now riding the bundled port channel instead of a single physical F port — bundling members must not change who's logged in, only how many physical links carry that traffic. `show npv status` confirms the FI-facing side's NPV/uplink state where run from the FI's NX-OS CLI context.
 
 !!! question "Check yourself"
-    What specifically causes an FC port channel member to fail to bundle even though the physical link is up — and how is that different from the Ethernet port-channel case?
+    A SAN port channel member sits in `(I)` individual state even though the physical link is up and the allowed-VSAN list matches on both ends. What's the one setting you haven't checked yet that's specific to F-port-channels and doesn't have an equivalent concern on the Ethernet port-channel side?
+
+[^fpc]: [Cisco Nexus 5000 Series NX-OS SAN Switching Configuration Guide, Release 5.1(3)N1(1) — Configuring SAN Port Channels](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/san_switching/513_n1_1/b_Cisco_n5k_nxos_sanswitching_config_guide_rel513_n1_1/b_Cisco_n5k_nxos_sanswitching_config_guide_rel513_n1_1_chapter_01000.html): only Active-Active mode is supported for F-port-channels; ON mode is not supported. `feature fport-channel-trunk` must be enabled before configuring an F port channel that trunks more than one VSAN.

--- a/docs/ucs-san/10-load-balancing.md
+++ b/docs/ucs-san/10-load-balancing.md
@@ -23,21 +23,45 @@ FC port channels load-balance per-exchange by default (OX_ID-based), which is al
     show san-port-channel summary
     ```
 
-## 10.3 Task 9.3 — UCS-Side Pinning and Failover
+## 10.3 Task 9.3 — Default Dynamic Pinning vs. vNIC Fabric Failover
 
 Two distinct mechanisms, don't conflate them:
 
+- **Default UCS dynamic pinning:** without any pin group configured, UCS Manager dynamically selects an appropriate uplink Ethernet port or port channel for each vNIC on its own. This selection is not permanent — it can change following events such as an uplink interface flap or a server reboot, since UCSM re-evaluates the assignment rather than remembering a specific prior choice.
 - **vNIC Fabric Failover** (a per-vNIC checkbox in the service profile): if the *primary* fabric's uplink fails, the vNIC's MAC moves to the other fabric's FI. This is a failover mechanism, not load balancing — only one fabric carries that vNIC's traffic at a time.
-- **Dynamic pinning / static pinning** of vNICs and vHBAs to specific uplink ports or port channels (**LAN/SAN > Policies > Pin Groups**): this is how UCSM spreads *multiple* vNICs/vHBAs across *multiple* uplinks for aggregate bandwidth, since a single vNIC's traffic itself is not split across links.
 
-## 10.4 Task 9.4 — VLAN Groups as a Traffic-Engineering Tool (ties back to Module 2.4)
+Neither of these requires you to configure anything — they're the platform default behavior. Task 9.4 below is what you configure when default dynamic pinning isn't precise enough for your needs.
 
-Port-channel hashing (10.1) balances flows *within* one bundle; it says nothing about which uplink a given VLAN's traffic prefers in the first place. That's what the VLAN Groups from Module 2.4 are for: pinning `VG-Data` (VLAN 10) to the uplink facing FI-A and `VG-Mgmt` (VLAN 11) to the uplink facing FI-B gives each VLAN a deterministic *primary* path, splitting normal-condition load across two physically separate uplinks by VLAN — a coarse, policy-driven form of load distribution that complements, rather than duplicates, the hash-based balancing inside each bundle. Because both VLANs stay trunked on both uplinks, this is a preference, not a hard split: either one keeps working over the other uplink if its pinned path fails.
+## 10.4 Task 9.4 — LAN and SAN Pin Groups
 
-Confirm this is actually happening rather than assumed: on N5K-1, `show interface Ethernet1/1 counters` (or `show interface counters trunk`) should show VLAN 10's traffic dominating its pinned uplink under normal conditions, with VLAN 11 doing the same on its own pinned uplink — not a hard zero on the non-preferred side, since both VLANs remain permitted on both trunks.
+**Objective:** understand when explicit pinning is worth the loss of UCSM's automatic uplink selection, and be able to prove where a vNIC's or vHBA's traffic actually lands once pinned.
+
+Manual pinning is **not** automatically a best practice — default dynamic pinning (10.3) already spreads load reasonably and re-adapts on its own after a link flap. Pin Groups trade that adaptability for determinism: useful when you need a specific vNIC or vHBA to land on a specific uplink for troubleshooting, capacity planning, or a change-control requirement that says "this traffic uses this exact path" — not because pinning is inherently superior to letting UCSM choose.
+
+**LAN Pin Groups** (**LAN > Policies > Pin Groups**) explicitly pin a server vNIC's Ethernet traffic to a selected uplink Ethernet port or Ethernet port channel. A LAN Pin Group isn't applied directly to a vNIC in isolation — it's consumed through the vNIC's own policy, template, or the service profile that references that vNIC.[^lanpin]
+
+**SAN Pin Groups** (**SAN > Policies > Pin Groups**) do the same for a vHBA's Fibre Channel traffic, pinning it to a selected FC uplink. Cisco's own documentation calls out one caveat worth knowing before you build one: **SAN Pin Groups have no effect when the Fabric Interconnect's FC switching mode is Switch Mode** — they're only relevant in **End Host Mode**, which is exactly the NPV-like mode this lab's FIs use (`05-fc-fcoe.md` §5.1). So for this lab's actual architecture, SAN Pin Groups are a real, usable tool, not a moot one.[^sanpin]
+
+**Build one (LAN side, as a worked example):**
+
+1. **LAN > Policies > Pin Groups > Create LAN Pin Group**, name it, and select the target uplink Ethernet port or port channel (e.g. the FI-A-facing uplink from Task 2.1).
+2. Reference that Pin Group from the relevant vNIC template or service profile's vNIC definition.
+
+**Verify the pin actually took effect** — don't assume it from the policy alone:
+
+??? "Commands"
+    ```text
+    show interface Ethernet1/1 counters
+    show interface counters trunk
+    ```
+
+Confirm the pinned vNIC's traffic actually lands on the uplink you selected, not just that the policy saved without error — a Pin Group that silently fails to apply (wrong org scope, vNIC not actually referencing it) looks identical to a working one until you check the counters.
 
 !!! question "Check yourself"
-    If you skipped VLAN Groups and just let both VLANs hash across both uplinks with no pinning preference at all, what specifically would you lose from a troubleshooting and change-control standpoint, even if raw throughput ended up about the same?
+    If you rely on default dynamic pinning instead of a LAN Pin Group, and the uplink a vNIC happened to land on flaps, what happens to that vNIC's traffic — does it stay pinned to a now-down uplink, or move? Now answer the same question for a vNIC that *is* explicitly pinned via a LAN Pin Group whose target uplink goes down. What's the actual trade-off you're making by pinning?
+
+[^lanpin]: [Cisco UCS Manager Network Management Guide Using the CLI, Release 6.0 — LAN Pin Groups](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/ucs-manager/CLI-User-Guides/Network-Mgmt/4-2/b_cli_ucsm_network_management_guide_4_2/b_CLI_UCSM_Network_Management_Guide_chapter_01010.html)
+[^sanpin]: Cisco UCS Manager Storage Management Guide, Release 6.0 — SAN Pin Groups: SAN Pin Groups are not relevant when the Fabric Interconnect is in Fibre Channel switch mode.
 
 !!! question "Check yourself"
     If a blade has only one vNIC per fabric, does enabling more uplink ports in that fabric's port channel increase that vNIC's individual throughput? Why or why not — and what would you add to actually increase it?

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,22 +30,24 @@ theme:
 nav:
   - Home: index.md
   - UCS & SAN:
-      - Overview: ucs-san/00-overview.md
-      - 01 · Pre-Lab Checklist: ucs-san/01-pre-lab.md
-      - 02 · Compute Policies: ucs-san/02-compute-policies.md
-      - 03 · SAN/LAN Uplinks: ucs-san/03-uplinks.md
-      - 04 · Port Modes: ucs-san/04-port-modes.md
-      - 05 · FC and FCoE: ucs-san/05-fc-fcoe.md
-      - 06 · Zoning: ucs-san/06-zoning.md
-      - 07 · NPV / NPIV: ucs-san/07-npv-npiv.md
-      - 08 · Trunking: ucs-san/08-trunking.md
-      - 09 · PortChannel: ucs-san/09-portchannel.md
-      - 10 · Load Balancing: ucs-san/10-load-balancing.md
-      - 11 · SAN Boot Verification: ucs-san/11-san-boot-verification.md
-      - 12 · Troubleshooting Drill: ucs-san/12-troubleshooting-drill.md
-      - Appendix: ucs-san/13-appendix.md
-      - "Standalone Lab · Configure a Service Profile": ucs-san/14-service-profile-standalone.md
-      - "Standalone Lab · Configure Basic Identity Pools": ucs-san/15-identity-pools-standalone.md
+      - End-to-End Guided Lab:
+          - Overview: ucs-san/00-overview.md
+          - Pre-Lab Checklist: ucs-san/01-pre-lab.md
+          - 01 · Compute Policies: ucs-san/02-compute-policies.md
+          - 02 · SAN/LAN Uplinks: ucs-san/03-uplinks.md
+          - 03 · Port Modes: ucs-san/04-port-modes.md
+          - 04 · FC and FCoE: ucs-san/05-fc-fcoe.md
+          - 05 · Zoning: ucs-san/06-zoning.md
+          - 06 · NPV / NPIV: ucs-san/07-npv-npiv.md
+          - 07 · Trunking: ucs-san/08-trunking.md
+          - 08 · PortChannel: ucs-san/09-portchannel.md
+          - 09 · Load Balancing: ucs-san/10-load-balancing.md
+          - 10 · SAN Boot Verification: ucs-san/11-san-boot-verification.md
+          - 11 · Troubleshooting Drill: ucs-san/12-troubleshooting-drill.md
+          - Appendix: ucs-san/13-appendix.md
+      - Standalone Labs:
+          - Configure a Service Profile: ucs-san/14-service-profile-standalone.md
+          - Configure Basic Identity Pools: ucs-san/15-identity-pools-standalone.md
   - NX-OS: nx-os/index.md
   - ACI:
       - Overview: aci/index.md


### PR DESCRIPTION
## Summary

Technical/structural correction pass on the UCS & SAN guided lab, per a technical review. Corrects real errors without rewriting the lab's Build → Verify → Prove → Break → Diagnose → Restore philosophy or its end-to-end SAN-boot objective.

### Technical corrections (P0)
- **VLAN Groups** (`03-uplinks.md`, `10-load-balancing.md`, `00-overview.md`): removed the "preferred/primary uplink with failover" framing. Corrected to Cisco's documented behavior — an uplink not associated with a VLAN Group stops supporting that group's VLANs. Reframed around disjoint Layer-2 networking, with a collapsed conceptual deep dive since this lab's own VLAN 10/11 are intentionally shared/redundant, not disjoint.
- **Load Balancing** (`10-load-balancing.md`): rebuilt around default UCS dynamic pinning plus LAN/SAN Pin Groups, including Cisco's documented caveat that SAN Pin Groups don't apply in FC switch mode (this lab uses NPV/End Host mode, so they do apply here).
- **VLAN 20/21 → 10/11** (`08-trunking.md`): fixed the one Fabric B trunk line that contradicted the guide's own shared-VLAN-10/11 convention used everywhere else. Left the unrelated VLAN 30/40 worked example and VLAN 50 troubleshooting ticket untouched — confirmed via full-tree audit these are intentional, separate examples.
- **SAN PortChannel F-port-channel** (`09-portchannel.md`): added `feature fport-channel-trunk`, explicit `channel mode active` (Cisco documents ON mode as unsupported for F-port-channels), and real verification (`show flogi database`, `show npv status`, `show san-port-channel summary`, etc).
- **Uplink role distinction + FC/FCoE as alternatives** (`03-uplinks.md`, `05-fc-fcoe.md`): added an explicit Ethernet/FCoE/Unified uplink table, and framed native FC vs. FCoE as alternative implementations (native FC is this pod's actual default per its own existing tasks; FCoE is the documented alternative, not an addition).

### Structural changes (P1)
- **vPC completed** (`09-portchannel.md`): the prior 6-line stub (feature vpc, domain, peer-keepalive, one downstream port channel) is now a full build — `feature lacp`, a real peer-link (L2 trunk, `spanning-tree port type network`, `vpc peer-link`) between N5K-1/N5K-2, full verification (`show vpc`, `show vpc brief`, consistency-parameters), and a troubleshooting note on a missing/inconsistent peer-link.
- **Collapsible theory**: the "Unbinding a Service Profile" worked example in `02-compute-policies.md` is now a collapsed `??? "📚 Worked Example"` block. Deliberately conservative elsewhere — most of the guide's explanatory prose sits directly before the task it justifies, so collapsing it would hide load-bearing rationale, not just theory (confirmed by reading each candidate section in full before deciding).
- **Standalone Labs separation**: `mkdocs.yml` nav restructured into two groups — "End-to-End Guided Lab" (Overview → Appendix) and "Standalone Labs" (Service Profile, Identity Pools) — so the standalone labs read as clearly separate from the SAN-boot sequence. **No files renamed, no public URLs changed** — only nav labels/grouping.
- **Module numbering**: nav labels renumbered 01–11 (dropping the double-counted Pre-Lab slot) to agree with each file's own internal "Module N" H1 text, which was already internally consistent — the mismatch was purely in the old nav label prefix, not the H1s themselves, so no H1 rewrites were needed.

## Cisco validation

- VLAN Groups restriction behavior: [Cisco UCS Manager Network Management Guide](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/ucs-manager/GUI-User-Guides/Network-Mgmt/4-2/b_UCSM_Network_Mgmt_Guide_4_2/b_UCSM_Network_Mgmt_Guide_chapter_0110.html) + [Upstream Disjointed Layer-2 Networks](https://www.cisco.com/c/en/us/td/docs/unified_computing/ucs/ucs-manager/CLI-User-Guides/Network-Mgmt/4-2/b_cli_ucsm_network_management_guide_4_2/b_CLI_UCSM_Network_Management_Guide_chapter_01010.html)
- LAN/SAN Pin Groups: Cisco UCS Manager Network Management Guide Using the CLI (LAN Pin Groups) + Storage Management Guide (SAN Pin Groups / FC switch-mode caveat)
- F-port-channel Active-mode requirement + `feature fport-channel-trunk`: [Cisco Nexus 5000 NX-OS SAN Switching Configuration Guide, Release 5.1(3)N1(1)](https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus5000/sw/san_switching/513_n1_1/b_Cisco_n5k_nxos_sanswitching_config_guide_rel513_n1_1/b_Cisco_n5k_nxos_sanswitching_config_guide_rel513_n1_1_chapter_01000.html)
- vPC peer-link `spanning-tree port type network` best practice: [Cisco Nexus vPC Best Practices Design Guide](https://www.cisco.com/c/dam/en/us/td/docs/switches/datacenter/sw/design/vpc_design/vpc_best_practices_design_guide.pdf)
- Ethernet/FCoE/Unified uplink roles, LAN VLAN/FCoE VLAN non-overlap: Cisco UCS Manager Network Management Guide — LAN Ports and Port Channels

## Build results

`mkdocs build --strict` passes clean, no warnings/errors. Consistency sweep for every flagged string (`VLAN 20`, `VLAN 21`, `preferred uplink`, `Module 12/13/14`, `Standalone Lab`/`Standalone Skill`, `san-port-channel`, `channel mode`, `FCoE VLAN`, literal `1000`/`2000`) came back clean — the only remaining `1000`/`2000`/`FCoE VLAN` hits are legitimate FC/FCoE-side VSAN↔VLAN mappings, never on an ordinary LAN trunk. Verified in the built HTML that both new nav groups render, and the new `<details>` blocks render collapsed by default with correctly nested fenced code blocks.

## Remaining uncertainties

- The exact physical member-interface names/count for the vPC peer-link (`Ethernet1/3-4` in the example) and the FI-facing bundle depend on this pod's actual cabling — flagged as an example to adapt, not asserted as this lab's real interface numbers (which I don't have visibility into from the repo alone).
- Whether `feature lacp` is already implicitly enabled on this pod's N5Ks (some NX-OS images enable it by default) — added explicitly since it's harmless if already on, but this couldn't be confirmed against the pod itself, only against documented Nexus 5000 behavior generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)