### PR TITLE
Remove Available now / Coming soon lists from home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,14 +2,4 @@
 
 Practice lab guides for CCIE Data Center preparation, built around hands-on pod topologies rather than pure theory review.
 
-## Available now
-
-- **[UCS & SAN](ucs-san/00-overview.md)** — a full Nexus DC-1 pod walkthrough: compute policies and templates, SAN/LAN uplinks, port modes, FC/FCoE, zoning, NPV/NPIV, trunking, port-channel, load balancing, and an end-to-end SAN boot verification, mapped to blueprint topics 4.1.a through 5.1.e.
-- **[NX-OS](nx-os/index.md)** — standalone Nexus switching labs, starting with virtual Port-Channel (vPC) basic configuration.
-
-## Coming soon
-
-- **ACI** — Application Centric Infrastructure fabric deployment and automation, including Terraform-based initial fabric bring-up.
-- **VXLAN EVPN** — VXLAN EVPN fabric configuration, troubleshooting, and Ansible-based automation.
-
 Use the search box above to jump straight to a topic, or the sidebar to browse by technology.


### PR DESCRIPTION
Removes the "Available now" and "Coming soon" bullet lists from `docs/index.md` per request. Sidebar nav + search already cover topic discovery, so this trims a summary that goes stale as sections get added.

`mkdocs build --strict` passes with zero warnings.